### PR TITLE
Implement module skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ An interactive phone system powered by open-source speech-to-text, LLMs, and TTS
 ...
 
 (Full README content skipped for brevity; already provided above)
+
+## Implemented Modules
+
+The current codebase includes placeholder modules matching the design:
+
+- `WhisperASR` in `app/modules/asr_whisper.py`
+- `OllamaLLM` in `app/modules/llm_ollama.py`
+- `PiperTTS` in `app/modules/tts_piper.py`
+
+Each implements a simple interface defined in the corresponding package's `__init__.py` file.

--- a/app/modules/asr/__init__.py
+++ b/app/modules/asr/__init__.py
@@ -1,0 +1,6 @@
+class BaseASR:
+    """Base interface for ASR modules."""
+
+    def transcribe(self, audio_path: str) -> str:
+        """Transcribe an audio file to text."""
+        raise NotImplementedError

--- a/app/modules/asr_whisper.py
+++ b/app/modules/asr_whisper.py
@@ -1,7 +1,14 @@
-class WhisperASR:
+from app.modules.asr import BaseASR
+
+
+class WhisperASR(BaseASR):
     """Placeholder ASR module using Whisper."""
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self.model_path = model_path
+        # In real implementation a Whisper model would be loaded here
+
     def transcribe(self, audio_path: str) -> str:
         """Return dummy transcription for given audio."""
         # TODO: integrate with Whisper ASR
         return "Hello"
-

--- a/app/modules/llm/__init__.py
+++ b/app/modules/llm/__init__.py
@@ -1,0 +1,6 @@
+class BaseLLM:
+    """Base interface for LLM modules."""
+
+    def generate(self, prompt: str) -> str:
+        """Generate a text response from a prompt."""
+        raise NotImplementedError

--- a/app/modules/llm_ollama.py
+++ b/app/modules/llm_ollama.py
@@ -1,7 +1,14 @@
-class OllamaLLM:
+from app.modules.llm import BaseLLM
+
+
+class OllamaLLM(BaseLLM):
     """Placeholder LLM module using an Ollama API."""
+
+    def __init__(self, endpoint: str = "http://localhost:11434") -> None:
+        self.endpoint = endpoint
+        # Real implementation would set up HTTP client here
+
     def generate(self, prompt: str) -> str:
         """Return a canned response for now."""
         # TODO: integrate with actual Ollama server
         return f"You said: {prompt}"
-

--- a/app/modules/tts/__init__.py
+++ b/app/modules/tts/__init__.py
@@ -1,0 +1,6 @@
+class BaseTTS:
+    """Base interface for TTS modules."""
+
+    def synthesize(self, text: str) -> bytes:
+        """Convert text to speech and return audio bytes."""
+        raise NotImplementedError

--- a/app/modules/tts_piper.py
+++ b/app/modules/tts_piper.py
@@ -1,7 +1,14 @@
-class PiperTTS:
+from app.modules.tts import BaseTTS
+
+
+class PiperTTS(BaseTTS):
     """Placeholder TTS module using Piper."""
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self.model_path = model_path
+        # In real implementation a Piper voice would be loaded here
+
     def synthesize(self, text: str) -> bytes:
         """Return dummy audio bytes."""
         # TODO: integrate with Piper TTS
         return b"audio-bytes"
-

--- a/docs/v_2_roadmap.md
+++ b/docs/v_2_roadmap.md
@@ -106,7 +106,7 @@ Tools:
 - [x] Set up placeholder modules
 - [x] Implement core event loop and HTTP interface
 - [x] Expand BDD tests for core modules
-- [ ] Begin implementing core modules
+- [x] Begin implementing core modules
 
 Let me know if you'd like to generate any starter files or templates next!
 

--- a/tickets.md
+++ b/tickets.md
@@ -34,11 +34,11 @@ Write additional BDD features covering ASR, TTS and memory modules as
 outlined in `docs/features/` for future development.
 
 ## T4 - Implement core module skeletons
-- [ ] Started
-- [ ] Behavior Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Started
+- [x] Behavior Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 ### Description
 Build initial ASR, TTS and LLM module classes with real method signatures as specified in `docs/v_2_design.md`. No external integrations yet.


### PR DESCRIPTION
## Summary
- add simple BaseASR, BaseLLM and BaseTTS interfaces
- flesh out placeholder WhisperASR, OllamaLLM and PiperTTS classes
- document modules in README
- update roadmap and mark T4 ticket complete

## Testing
- `pip install -r requirements.txt`
- `behave -q tests`

------
https://chatgpt.com/codex/tasks/task_e_687ba7f7dde48332a4249b009aa830ed