### PR TITLE
Add persistent memory integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ The current codebase includes placeholder modules matching the design:
 - `PiperTTS` in `app/modules/tts_piper.py`
 
 Each implements a simple interface defined in the corresponding package's `__init__.py` file.
+
+- `ContextManager` in `app/core/context_manager.py` supports optional
+  persistence of conversation history.
+- `CallHandler` can be initialised with a storage path so that dialogue is
+  saved across calls.

--- a/app/core/call_handler.py
+++ b/app/core/call_handler.py
@@ -4,11 +4,25 @@ from app.core.context_manager import ContextManager
 class CallHandler:
     """Manage a single call by orchestrating ASR, LLM, and TTS."""
 
-    def __init__(self, asr, llm, tts, context: ContextManager | None = None):
+    def __init__(self, asr, llm, tts, context: ContextManager | None = None,
+                 storage_path: str | None = None):
+        """Create a call handler.
+
+        Parameters
+        ----------
+        asr, llm, tts
+            Module instances used during the call.
+        context
+            Optional pre-configured context manager instance.
+        storage_path
+            Path to a memory file for persistent history if ``context`` is not
+            provided.
+        """
         self.asr = asr
         self.llm = llm
         self.tts = tts
-        self.context = context or ContextManager()
+        # Use provided context or create one, optionally with persistence
+        self.context = context or ContextManager(storage_path=storage_path)
 
     def handle(self, audio_path: str) -> bytes:
         """Process an audio file and return audio response."""

--- a/docs/v_2_roadmap.md
+++ b/docs/v_2_roadmap.md
@@ -107,6 +107,7 @@ Tools:
 - [x] Implement core event loop and HTTP interface
 - [x] Expand BDD tests for core modules
 - [x] Begin implementing core modules
+- [x] Add persistent memory support
 
 Let me know if you'd like to generate any starter files or templates next!
 

--- a/tests/steps/call_handler_steps.py
+++ b/tests/steps/call_handler_steps.py
@@ -1,0 +1,28 @@
+from behave import given, when, then
+import tempfile
+import os
+
+from app.core.call_handler import CallHandler
+from app.modules.asr_whisper import WhisperASR
+from app.modules.llm_ollama import OllamaLLM
+from app.modules.tts_piper import PiperTTS
+
+@given('a call handler with persistent memory')
+def step_given_persistent_handler(context):
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    context.memory_file = tmp.name
+    context.handler = CallHandler(WhisperASR(), OllamaLLM(), PiperTTS(),
+                                  storage_path=context.memory_file)
+
+@when('I process an audio file')
+def step_when_process_audio(context):
+    context.handler.handle('/tmp/input.wav')
+
+@then('the memory file contains the transcription and reply')
+def step_then_memory_file_contents(context):
+    with open(context.memory_file, 'r') as f:
+        contents = f.read()
+    assert 'Hello' in contents
+    assert 'You said: Hello' in contents
+    os.unlink(context.memory_file)

--- a/tests/test_call_handler.feature
+++ b/tests/test_call_handler.feature
@@ -1,0 +1,5 @@
+Feature: Call handler persistence
+  Scenario: CallHandler persists conversation to disk
+    Given a call handler with persistent memory
+    When I process an audio file
+    Then the memory file contains the transcription and reply

--- a/tickets.md
+++ b/tickets.md
@@ -44,11 +44,11 @@ outlined in `docs/features/` for future development.
 Build initial ASR, TTS and LLM module classes with real method signatures as specified in `docs/v_2_design.md`. No external integrations yet.
 
 ## T5 - Add persistent memory support
-- [ ] Started
-- [ ] Behavior Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Started
+- [x] Behavior Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 ### Description
 Extend `ContextManager` to optionally persist history to disk and integrate it with `CallHandler`. Add BDD scenario for persistent memory.


### PR DESCRIPTION
## Summary
- integrate optional storage path for CallHandler
- add BDD feature and steps verifying call handler persistence
- document persistent memory in README and roadmap
- mark ticket T5 complete

## Testing
- `behave tests`

------
https://chatgpt.com/codex/tasks/task_e_687bac7272188332bca499003d42c979