### PR TITLE
Implement scheduler jitter tests

### DIFF
--- a/docs/v_2_roadmap.md
+++ b/docs/v_2_roadmap.md
@@ -83,7 +83,7 @@ Tools:
 - [ ] Reference previous calls (context aware)
 - [ ] Interruptible AI responses using voice activity detection
 - [ ] Schedule outbound calls to extensions 601-608
-- [ ] Add randomness to call interval (avg every 30 minutes)
+- [x] Add randomness to call interval (avg every 30 minutes)
 - [ ] Restrict call times (e.g., avoid night)
 - [ ] Implement memory aging / pruning
 

--- a/tests/steps/scheduler_steps.py
+++ b/tests/steps/scheduler_steps.py
@@ -12,6 +12,10 @@ def step_given_scheduler(context, minutes, jitter):
     context.scheduler.next_interval = context.scheduler._calculate_interval()
     context.scheduler.last_call = 0
 
+@given('call window hours start {start:d} end {end:d}')
+def step_given_hours(context, start, end):
+    context.scheduler.config['hours'] = {'start': start, 'end': end}
+
 @when('I calculate the next interval')
 def step_when_calc_interval(context):
     context.interval = context.scheduler._calculate_interval()
@@ -23,7 +27,12 @@ def step_then_interval_range(context, low, high):
 @when('I check if it should call now')
 def step_when_should_call_now(context):
     context.should_call = context.scheduler.should_call_now()
+    context.interval = context.scheduler.next_interval
 
 @then('it returns True')
 def step_then_returns_true(context):
     assert context.should_call is True
+
+@then('it returns False')
+def step_then_returns_false(context):
+    assert context.should_call is False

--- a/tests/test_scheduler.feature
+++ b/tests/test_scheduler.feature
@@ -8,3 +8,15 @@ Feature: Call scheduling
     Given a scheduler with interval 0 and jitter 0
     When I check if it should call now
     Then it returns True
+
+  Scenario: No call outside hours
+    Given a scheduler with interval 0 and jitter 0
+    And call window hours start 23 end 23
+    When I check if it should call now
+    Then it returns False
+
+  Scenario: Next interval randomized after call
+    Given a scheduler with interval 30 and jitter 5
+    When I check if it should call now
+    Then it returns True
+    And the interval is between 25 and 35

--- a/tickets.md
+++ b/tickets.md
@@ -54,6 +54,17 @@ Build initial ASR, TTS and LLM module classes with real method signatures as spe
 Extend `ContextManager` to optionally persist history to disk and integrate it with `CallHandler`. Add BDD scenario for persistent memory.
 
 ## T6 - Scheduler randomness and tests
+- [x] Started
+- [x] Behavior Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
+
+### Description
+Enhance `CallScheduler` with configurable jitter to randomize call intervals and
+add BDD scenarios covering scheduling logic.
+
+## T7 - Night mode scheduling
 - [ ] Started
 - [ ] Behavior Written
 - [ ] Code Written
@@ -61,5 +72,5 @@ Extend `ContextManager` to optionally persist history to disk and integrate it w
 - [ ] Documentation Written
 
 ### Description
-Enhance `CallScheduler` with configurable jitter to randomize call intervals and
-add BDD scenarios covering scheduling logic.
+Restrict outbound calls to daytime hours using scheduler configuration and add
+BDD scenarios verifying calls are blocked outside this window.


### PR DESCRIPTION
## Summary
- verify scheduler jitter and hours logic
- test next interval recalculation
- mark roadmap task for scheduler randomness complete
- close ticket T6 and open T7 for night mode work

## Testing
- `behave tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbdbec2b883328ed98bed607b2fee