### PR TITLE
Implement night mode scheduling

### DIFF
--- a/app/modules/scheduler.py
+++ b/app/modules/scheduler.py
@@ -3,14 +3,18 @@ import os
 import time
 import random
 from datetime import datetime
+from typing import Callable
 
 
 class CallScheduler:
     """Simple scheduler reading config from JSON."""
 
-    def __init__(self, config_path: str = "app/config/schedule.json") -> None:
+    def __init__(self, config_path: str = "app/config/schedule.json",
+                 now_fn: Callable[[], datetime] | None = None) -> None:
         self.config = self._load_config(config_path)
         self.last_call = 0.0
+        # allow injection of current time for tests
+        self.now_fn = now_fn or datetime.now
         # determine interval with jitter for first call
         self.next_interval = self._calculate_interval()
 
@@ -35,7 +39,7 @@ class CallScheduler:
         """Return True if a call should be initiated."""
         if not self.config.get("enabled", False):
             return False
-        now = datetime.now()
+        now = self.now_fn()
         hours = self.config.get("hours", {})
         start = hours.get("start", 9)
         end = hours.get("end", 17)

--- a/docs/features/night_mode.feature
+++ b/docs/features/night_mode.feature
@@ -1,1 +1,7 @@
 Feature: Night Mode
+  Scenario: Calls are blocked outside configured hours
+    Given a scheduler with interval 0 and jitter 0
+    And call window hours start 9 end 17
+    And current hour is 3
+    When I check if it should call now
+    Then it returns False

--- a/docs/v_2_roadmap.md
+++ b/docs/v_2_roadmap.md
@@ -84,7 +84,7 @@ Tools:
 - [ ] Interruptible AI responses using voice activity detection
 - [ ] Schedule outbound calls to extensions 601-608
 - [x] Add randomness to call interval (avg every 30 minutes)
-- [ ] Restrict call times (e.g., avoid night)
+- [x] Restrict call times (e.g., avoid night)
 - [ ] Implement memory aging / pruning
 
 ---

--- a/tests/steps/scheduler_steps.py
+++ b/tests/steps/scheduler_steps.py
@@ -1,4 +1,5 @@
 from behave import given, when, then
+from datetime import datetime
 
 from app.modules.scheduler import CallScheduler
 
@@ -11,6 +12,10 @@ def step_given_scheduler(context, minutes, jitter):
     context.scheduler.config['jitter_minutes'] = jitter
     context.scheduler.next_interval = context.scheduler._calculate_interval()
     context.scheduler.last_call = 0
+
+@given('current hour is {hour:d}')
+def step_given_current_hour(context, hour):
+    context.scheduler.now_fn = lambda: datetime(2023, 1, 1, hour, 0, 0)
 
 @given('call window hours start {start:d} end {end:d}')
 def step_given_hours(context, start, end):

--- a/tests/test_scheduler.feature
+++ b/tests/test_scheduler.feature
@@ -12,8 +12,16 @@ Feature: Call scheduling
   Scenario: No call outside hours
     Given a scheduler with interval 0 and jitter 0
     And call window hours start 23 end 23
+    And current hour is 3
     When I check if it should call now
     Then it returns False
+
+  Scenario: Daytime call allowed within hours
+    Given a scheduler with interval 0 and jitter 0
+    And call window hours start 9 end 17
+    And current hour is 10
+    When I check if it should call now
+    Then it returns True
 
   Scenario: Next interval randomized after call
     Given a scheduler with interval 30 and jitter 5

--- a/tickets.md
+++ b/tickets.md
@@ -65,6 +65,17 @@ Enhance `CallScheduler` with configurable jitter to randomize call intervals and
 add BDD scenarios covering scheduling logic.
 
 ## T7 - Night mode scheduling
+- [x] Started
+- [x] Behavior Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
+
+### Description
+Restrict outbound calls to daytime hours using scheduler configuration and add
+BDD scenarios verifying calls are blocked outside this window.
+
+## T8 - Reference previous calls in context
 - [ ] Started
 - [ ] Behavior Written
 - [ ] Code Written
@@ -72,5 +83,6 @@ add BDD scenarios covering scheduling logic.
 - [ ] Documentation Written
 
 ### Description
-Restrict outbound calls to daytime hours using scheduler configuration and add
-BDD scenarios verifying calls are blocked outside this window.
+Enhance `ContextManager` and `CallHandler` so that the LLM prompt includes
+summaries from previous calls. Add BDD tests ensuring past conversation
+snippets are referenced when generating responses.


### PR DESCRIPTION
## Summary
- inject `now_fn` in `CallScheduler` for deterministic testing
- expand scheduler steps to allow specifying current hour
- test scheduler night/day behavior and document in feature file
- document night-mode behavior in roadmap and docs
- close T7, create T8 ticket for future work

## Testing
- `pip install -q -r requirements.txt`
- `behave -q tests`

------
https://chatgpt.com/codex/tasks/task_e_687bc30b85e883328b97162f97454112