### PR TITLE
Implement previous call context

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ Each implements a simple interface defined in the corresponding package's `__ini
 - `ContextManager` in `app/core/context_manager.py` supports optional
   persistence of conversation history.
 - `CallHandler` can be initialised with a storage path so that dialogue is
-  saved across calls.
+  saved across calls. Summaries are written with a `SUMMARY:` prefix so the
+  next call can include context from prior conversations.

--- a/app/core/call_handler.py
+++ b/app/core/call_handler.py
@@ -28,8 +28,11 @@ class CallHandler:
         """Process an audio file and return audio response."""
         text = self.asr.transcribe(audio_path)
         self.context.add_entry(text)
-        reply = self.llm.generate(self.context.summarize())
+        prompt = self.context.get_context()
+        reply = self.llm.generate(prompt)
         self.context.add_entry(reply)
         audio = self.tts.synthesize(reply)
+        # persist summary so next call includes this dialogue
+        self.context.save_summary()
         return audio
 

--- a/app/core/context_manager.py
+++ b/app/core/context_manager.py
@@ -4,12 +4,27 @@ import os
 class ContextManager:
     """Simple context store with optional persistence."""
 
+    SUMMARY_PREFIX = "SUMMARY: "
+
     def __init__(self, storage_path: str | None = None):
         self.storage_path = storage_path
+        # per-call history
         self.history: list[str] = []
+        # summaries of previous calls
+        self.past_summaries: list[str] = []
         if self.storage_path and os.path.exists(self.storage_path):
             with open(self.storage_path, "r") as f:
-                self.history = [line.strip() for line in f if line.strip()]
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    if line.startswith(self.SUMMARY_PREFIX):
+                        self.past_summaries.append(
+                            line[len(self.SUMMARY_PREFIX) :]
+                        )
+                    else:
+                        # treat plain lines from older files as summaries
+                        self.past_summaries.append(line)
 
     def add_entry(self, text: str) -> None:
         self.history.append(text)
@@ -20,4 +35,17 @@ class ContextManager:
     def summarize(self) -> str:
         """Return concatenated summary for now."""
         return " ".join(self.history[-5:])
+
+    def get_context(self) -> str:
+        """Return prompt including past summaries and current history."""
+        return " ".join(self.past_summaries[-5:] + self.history[-5:])
+
+    def save_summary(self) -> None:
+        """Persist summary of current history and reset it."""
+        summary = self.summarize()
+        if self.storage_path:
+            with open(self.storage_path, "a") as f:
+                f.write(f"{self.SUMMARY_PREFIX}{summary}\n")
+        self.past_summaries.append(summary)
+        self.history.clear()
 

--- a/docs/v_2_design.md
+++ b/docs/v_2_design.md
@@ -69,6 +69,8 @@ ai_phone_v2/
 ### Context Manager
 - Stores per-character memory (conversation summaries)
 - Appends new summarized call data
+- Summaries are written to disk prefixed with `SUMMARY:` so later calls can
+  reference prior conversations
 - Uses summarization to avoid unbounded memory growth
 
 ### Scheduler

--- a/docs/v_2_roadmap.md
+++ b/docs/v_2_roadmap.md
@@ -80,7 +80,7 @@ Tools:
 
 ## 🌟 Phase 4: Features & Intelligence
 - [x] Summarize memory at end of call
-- [ ] Reference previous calls (context aware)
+- [x] Reference previous calls (context aware)
 - [ ] Interruptible AI responses using voice activity detection
 - [ ] Schedule outbound calls to extensions 601-608
 - [x] Add randomness to call interval (avg every 30 minutes)

--- a/tests/steps/call_handler_steps.py
+++ b/tests/steps/call_handler_steps.py
@@ -19,10 +19,22 @@ def step_given_persistent_handler(context):
 def step_when_process_audio(context):
     context.handler.handle('/tmp/input.wav')
 
+@when('I process another audio file')
+def step_when_process_another_audio(context):
+    context.handler.handle('/tmp/input.wav')
+
 @then('the memory file contains the transcription and reply')
 def step_then_memory_file_contents(context):
     with open(context.memory_file, 'r') as f:
         contents = f.read()
     assert 'Hello' in contents
     assert 'You said: Hello' in contents
+    os.unlink(context.memory_file)
+
+@then('the memory file contains two summaries')
+def step_then_two_summaries(context):
+    with open(context.memory_file, 'r') as f:
+        lines = f.readlines()
+    summary_lines = [ln for ln in lines if ln.startswith('SUMMARY:')]
+    assert len(summary_lines) >= 2
     os.unlink(context.memory_file)

--- a/tests/steps/memory_steps.py
+++ b/tests/steps/memory_steps.py
@@ -28,7 +28,7 @@ def step_when_trimming(context):
 
 @then('the summary contains "{text}"')
 def step_then_summary_contains(context, text):
-    summary = context.manager.summarize()
+    summary = context.manager.get_context()
     assert text in summary
 
 @then('a combined string of recent statements is returned')

--- a/tests/test_call_handler.feature
+++ b/tests/test_call_handler.feature
@@ -3,3 +3,9 @@ Feature: Call handler persistence
     Given a call handler with persistent memory
     When I process an audio file
     Then the memory file contains the transcription and reply
+
+  Scenario: CallHandler references previous calls
+    Given a call handler with persistent memory
+    When I process an audio file
+    And I process another audio file
+    Then the memory file contains two summaries

--- a/tickets.md
+++ b/tickets.md
@@ -76,6 +76,18 @@ Restrict outbound calls to daytime hours using scheduler configuration and add
 BDD scenarios verifying calls are blocked outside this window.
 
 ## T8 - Reference previous calls in context
+- [x] Started
+- [x] Behavior Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
+
+### Description
+Enhance `ContextManager` and `CallHandler` so that the LLM prompt includes
+summaries from previous calls. Add BDD tests ensuring past conversation
+snippets are referenced when generating responses.
+
+## T9 - Interruptible AI responses
 - [ ] Started
 - [ ] Behavior Written
 - [ ] Code Written
@@ -83,6 +95,6 @@ BDD scenarios verifying calls are blocked outside this window.
 - [ ] Documentation Written
 
 ### Description
-Enhance `ContextManager` and `CallHandler` so that the LLM prompt includes
-summaries from previous calls. Add BDD tests ensuring past conversation
-snippets are referenced when generating responses.
+Implement voice activity detection to stop TTS playback when the caller
+begins speaking. Write BDD scenarios verifying that playback halts when
+input is detected mid-response.


### PR DESCRIPTION
## Summary
- store past call summaries in `ContextManager`
- update `CallHandler` to include prior summaries and persist them
- test referencing previous calls in BDD scenarios
- document summary prefix usage in README and design doc
- update roadmap and tickets for completed task

## Testing
- `pip install -r requirements.txt`
- `behave -q tests`

------
https://chatgpt.com/codex/tasks/task_e_687bcb8fa4a48332baf304e2d6d4d99b