### PR TITLE
Implement memory trimming

### DIFF
--- a/app/core/context_manager.py
+++ b/app/core/context_manager.py
@@ -2,12 +2,13 @@ import os
 
 
 class ContextManager:
-    """Simple context store with optional persistence."""
+    """Simple context store with optional persistence and trimming."""
 
     SUMMARY_PREFIX = "SUMMARY: "
 
-    def __init__(self, storage_path: str | None = None):
+    def __init__(self, storage_path: str | None = None, memory_limit: int | None = None):
         self.storage_path = storage_path
+        self.memory_limit = memory_limit
         # per-call history
         self.history: list[str] = []
         # summaries of previous calls
@@ -31,6 +32,14 @@ class ContextManager:
         if self.storage_path:
             with open(self.storage_path, "a") as f:
                 f.write(text + "\n")
+        # trim history if needed after adding new entry
+        self.trim_history()
+
+    def trim_history(self, limit: int | None = None) -> None:
+        """Trim stored history to at most ``limit`` entries."""
+        limit = limit if limit is not None else self.memory_limit
+        if limit is not None and len(self.history) > limit:
+            self.history = self.history[-limit:]
 
     def summarize(self) -> str:
         """Return concatenated summary for now."""

--- a/docs/v_2_roadmap.md
+++ b/docs/v_2_roadmap.md
@@ -85,7 +85,7 @@ Tools:
 - [x] Schedule outbound calls to extensions 601-608
 - [x] Add randomness to call interval (avg every 30 minutes)
 - [x] Restrict call times (e.g., avoid night)
-- [ ] Implement memory aging / pruning
+- [x] Implement memory aging / pruning
 
 ---
 

--- a/tests/steps/memory_steps.py
+++ b/tests/steps/memory_steps.py
@@ -12,6 +12,14 @@ def step_given_context_with_history(context):
     context.manager.add_entry("Hello")
     context.manager.add_entry("How are you?")
 
+@given('a context manager with history longer than limit')
+def step_given_history_longer(context):
+    """Create a manager with more than two entries."""
+    context.manager = ContextManager()
+    context.manager.add_entry("Hello")
+    context.manager.add_entry("How are you?")
+    context.manager.add_entry("Goodbye")
+
 @when('I add "{text}" to memory')
 def step_when_add_memory(context, text):
     context.manager.add_entry(text)
@@ -22,9 +30,7 @@ def step_when_request_summary(context):
 
 @when('trimming is invoked')
 def step_when_trimming(context):
-    # Simplistic trimming to last 2 entries
-    if len(context.manager.history) > 2:
-        context.manager.history = context.manager.history[-2:]
+    context.manager.trim_history(2)
 
 @then('the summary contains "{text}"')
 def step_then_summary_contains(context, text):

--- a/tests/test_memory.feature
+++ b/tests/test_memory.feature
@@ -11,3 +11,8 @@ Feature: Memory module
     When I add "Persistent" to memory
     And I reload the context manager
     Then the summary contains "Persistent"
+
+  Scenario: History trimmed when exceeding limit
+    Given a context manager with history longer than limit
+    When trimming is invoked
+    Then only the most recent entries remain

--- a/tickets.md
+++ b/tickets.md
@@ -108,3 +108,14 @@ input is detected mid-response.
 
 ### Description
 Implement dialing logic to call extensions 601-608 at randomized intervals as per schedule configuration.
+
+## T11 - Memory pruning feature
+- [x] Started
+- [x] Behavior Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
+
+### Description
+Add trimming capability to `ContextManager` with a `trim_history` method and new
+BDD scenario ensuring old entries are removed when history exceeds a limit.


### PR DESCRIPTION
## Summary
- add optional memory limits to ContextManager
- implement `trim_history` and call it from add_entry
- test memory trimming with new BDD scenario
- mark roadmap and tickets complete for memory pruning

## Testing
- `behave -q tests`

------
https://chatgpt.com/codex/tasks/task_e_687be721a25c83329d6269a980aea0b0